### PR TITLE
Implemented: Url link shorten handler workflow event option drop down menu

### DIFF
--- a/classes/handlers/linkshorten/nxcSocialNetworksLinkShortenHandler.php
+++ b/classes/handlers/linkshorten/nxcSocialNetworksLinkShortenHandler.php
@@ -28,6 +28,11 @@ class nxcSocialNetworksLinkShortenHandler
 		}
 	}
 
+	public static function getHandlers() {
+		$ini = eZINI::instance( 'nxcsocialnetworks.ini' );
+		return (array) $ini->variable( 'General', 'LinkShortenHandlers' );
+	}
+
 	public function shortenUrl( $serviceApiCallUrl, $type = 'get', $postData = null ) {
 		$shortUrl = false;
 

--- a/classes/handlers/linkshorten/nxcSocialNetworksLinkShortenHandlerBitly.php
+++ b/classes/handlers/linkshorten/nxcSocialNetworksLinkShortenHandlerBitly.php
@@ -8,13 +8,15 @@
 
 class nxcSocialNetworksLinkShortenHandlerBitly extends nxcSocialNetworksLinkShortenHandler
 {
+	public $name = "Bit.ly";
+
 	public function shorten( $url ) {
 		$shortUrl = false;
 		$bitly = new Bitly( null, null, eZINI::instance( 'nxcsocialnetworks.ini' )->variable( 'LinkShortenHandlerBitly', 'GenericAccessToken' ) );
 
 		try {
-			$responce = $bitly->shorten( $url );
-			$responseUrl = $responce['url'];
+			$response = $bitly->shorten( $url );
+			$responseUrl = $response['url'];
 
 			if( $responseUrl != '' ) {
 				$shortUrl = $responseUrl;

--- a/classes/handlers/linkshorten/nxcSocialNetworksLinkShortenHandlerGoogl.php
+++ b/classes/handlers/linkshorten/nxcSocialNetworksLinkShortenHandlerGoogl.php
@@ -8,6 +8,7 @@
 
 class nxcSocialNetworksLinkShortenHandlerGoogl extends nxcSocialNetworksLinkShortenHandler
 {
+	public $name = "Goo.gl";
 	public $serviceCallUrl = "https://www.googleapis.com/urlshortener/v1/url";
 
 	public function shorten( $url ) {

--- a/classes/handlers/linkshorten/nxcSocialNetworksLinkShortenHandlerIsgd.php
+++ b/classes/handlers/linkshorten/nxcSocialNetworksLinkShortenHandlerIsgd.php
@@ -8,6 +8,7 @@
 
 class nxcSocialNetworksLinkShortenHandlerIsgd extends nxcSocialNetworksLinkShortenHandler
 {
+	public $name = "is.gd";
 	public $serviceCallUrl = "http://is.gd/create.php?format=simple&url=";
 
 	public function shorten( $url ) {

--- a/classes/handlers/linkshorten/nxcSocialNetworksLinkShortenHandlerOwly.php
+++ b/classes/handlers/linkshorten/nxcSocialNetworksLinkShortenHandlerOwly.php
@@ -8,6 +8,8 @@
 
 class nxcSocialNetworksLinkShortenHandlerOwly extends nxcSocialNetworksLinkShortenHandler
 {
+	public $name = "Ow.ly";
+
 	public function shorten( $url ) {
 		$shortUrl = false;
 		$owly = OwlyApi::factory( array( 'key' => eZINI::instance( 'nxcsocialnetworks.ini' )->variable( 'LinkShortenHandlerOwly', 'ApiKey' ) ) );

--- a/classes/handlers/linkshorten/nxcSocialNetworksLinkShortenHandlerTinyurl.php
+++ b/classes/handlers/linkshorten/nxcSocialNetworksLinkShortenHandlerTinyurl.php
@@ -8,6 +8,7 @@
 
 class nxcSocialNetworksLinkShortenHandlerTinyurl extends nxcSocialNetworksLinkShortenHandler
 {
+	public $name = "TinyUrl.com";
 	public $serviceCallUrl = "http://tinyurl.com/api-create.php?url=";
 
 	public function shorten( $url ) {

--- a/classes/handlers/linkshorten/nxcSocialNetworksLinkShortenHandlerToly.php
+++ b/classes/handlers/linkshorten/nxcSocialNetworksLinkShortenHandlerToly.php
@@ -8,6 +8,7 @@
 
 class nxcSocialNetworksLinkShortenHandlerToly extends nxcSocialNetworksLinkShortenHandler
 {
+	public $name = "to.ly";
 	public $serviceCallUrl = "http://to.ly/api.php?longurl=";
 
 	public function shorten( $url ) {

--- a/classes/handlers/linkshorten/nxcSocialNetworksLinkShortenHandlerVgd.php
+++ b/classes/handlers/linkshorten/nxcSocialNetworksLinkShortenHandlerVgd.php
@@ -8,6 +8,7 @@
 
 class nxcSocialNetworksLinkShortenHandlerVgd extends nxcSocialNetworksLinkShortenHandler
 {
+	public $name = "v.gd";
 	public $serviceCallUrl = "http://v.gd/create.php?format=simple&url=";
 
 	public function shorten( $url ) {

--- a/classes/handlers/publish/facebook.php
+++ b/classes/handlers/publish/facebook.php
@@ -41,7 +41,7 @@ class nxcSocialNetworksPublishHandlerFacebook extends nxcSocialNetworksPublishHa
 				isset( $options['shorten_url'] )
 				&& (bool) $options['shorten_url'] === true
 			) {
-				$urlReturned = $this->shorten( $url );
+				$urlReturned = $this->shorten( $url, $options['shorten_handler'] );
 				if( is_string( $urlReturned ) ) {
 					$url = $urlReturned;
 				}

--- a/classes/handlers/publish/linkedin.php
+++ b/classes/handlers/publish/linkedin.php
@@ -33,7 +33,7 @@ class nxcSocialNetworksPublishHandlerLinkedIn extends nxcSocialNetworksPublishHa
 				isset( $options['shorten_url'] )
 				&& (bool) $options['shorten_url'] === true
 			) {
-				$urlReturned = $this->shorten( $url );
+				$urlReturned = $this->shorten( $url, $options['shorten_handler'] );
 				if( is_string( $urlReturned ) ) {
 					$url = $urlReturned;
 				}

--- a/classes/handlers/publish/twitter.php
+++ b/classes/handlers/publish/twitter.php
@@ -26,7 +26,7 @@ class nxcSocialNetworksPublishHandlerTwitter extends nxcSocialNetworksPublishHan
 				isset( $options['shorten_url'] )
 				&& (bool) $options['shorten_url'] === true
 			) {
-				$urlReturned = $this->shorten( $url );
+				$urlReturned = $this->shorten( $url, $options['shorten_handler'] );
 				if( is_string( $urlReturned ) ) {
 					$url = $urlReturned;
 				}

--- a/classes/publish.php
+++ b/classes/publish.php
@@ -185,8 +185,12 @@ class nxcSocialNetworksPublishHandler extends eZPersistentObject
 		return false;
 	}
 
-	public function shorten( $url ) {
-		return nxcSocialNetworksLinkShortenHandler::instance()->shorten( $url );
+	public function shorten( $url, $handler = null ) {
+		if( $handler != null ) {
+			return nxcSocialNetworksLinkShortenHandler::instance( $handler )->shorten( $url );
+		} else {
+			return nxcSocialNetworksLinkShortenHandler::instance()->shorten( $url );
+		}
 	}
 }
 ?>

--- a/design/standard/stylesheets/nxc_social_networks.css
+++ b/design/standard/stylesheets/nxc_social_networks.css
@@ -14,7 +14,9 @@ a.nxc-facebook-signin:active, a.nxc-twitter-signin:active, a.nxc-linkedin-signin
 div.nxc-social-networks-login { margin: 0px -5px 0px -5px; }
 div.nxc-social-networks-login a { margin: 5px; float: left; }
 
-table.list td.nxc-social-network-td-container { padding: 10px; vertical-align: top;}
+table.list td.nxc-social-network-td-container { padding: 10px; vertical-align: top; }
 table.list label.nxc-social-network-attribute-header, label.nxc-social-network-attribute-header { font-weight: bold; padding-bottom: 5px; color: #333; }
-table.nxc-social-network-attribute-list { margin-bottom: 10px;}
-.nxc-social-network-attribute-controlbar { padding-bottom: 10px;}
+table.nxc-social-network-attribute-list { margin-bottom: 10px; }
+.nxc-social-network-attribute-controlbar { padding-bottom: 10px; }
+
+label.nxc-social-network-attribute-select { display: inline; }

--- a/design/standard/templates/workflow/eventtype/edit/event_nxcsocialnetworkspublish.tpl
+++ b/design/standard/templates/workflow/eventtype/edit/event_nxcsocialnetworkspublish.tpl
@@ -80,6 +80,14 @@
 						<label class="nxc-social-network-attribute-checkbox"><input type="checkbox" name="WorkflowEvent_event_nxcsocialnetworkspublish_handler_options[shorten_url][{$handler.id}]" value="1" {if $handler.options.shorten_url}checked="checked"{/if}/>
 						{'Shorten node`s URL'|i18n( 'extension/nxc_social_networks' )}</label>
 
+						<label class="nxc-social-network-attribute-select">{'Shorten node`s URL Service'|i18n( 'extension/nxc_social_networks' )}:</label>
+						<select name="WorkflowEvent_event_nxcsocialnetworkspublish_handler_options[shorten_handler][{$handler.id}]">
+							{if $handler.options.shorten_handler|eq( '' )}<option value="" selected>None</option>{/if}
+							{foreach $event.available_shorten_handler_names as $type => $name}
+								<option value="{$type}"{if $handler.options.shorten_handler|eq( $type )} selected{/if}>{$name}</option>
+							{/foreach}
+						</select>
+
 						{if $handler.has_extra_options}
 							{include
 								uri=concat( 'design:', $handler.extra_options_edit_template )

--- a/design/standard/templates/workflow/eventtype/view/event_nxcsocialnetworkspublish.tpl
+++ b/design/standard/templates/workflow/eventtype/view/event_nxcsocialnetworkspublish.tpl
@@ -40,6 +40,8 @@
 
 						<label class="nxc-social-network-attribute-checkbox">{'Shorten node`s URL'|i18n( 'extension/nxc_social_networks' )}: {if $handler.options.shorten_url}{'Yes'|i18n( 'extension/nxc_social_networks' )}{else}{'No'|i18n( 'extension/nxc_social_networks' )}{/if}</label>
 
+						<label class="nxc-social-network-attribute-select">{'Shorten node`s URL Service'|i18n( 'extension/nxc_social_networks' )}: {if $handler.options.shorten_handler}{foreach $event.available_shorten_handler_names as $type => $name}{if $handler.options.shorten_handler|eq( $type )}{$name}{/if}{/foreach}{else}{'None'|i18n( 'extension/nxc_social_networks' )}{/if}</label>
+
 						{if $handler.has_extra_options}
 							{include
 								uri=concat( 'design:', $handler.extra_options_view_template )

--- a/eventtypes/event/nxcsocialnetworkspublish/nxcsocialnetworkspublishtype.php
+++ b/eventtypes/event/nxcsocialnetworkspublish/nxcsocialnetworkspublishtype.php
@@ -10,8 +10,9 @@ class nxcSocialNetworksPublishType extends eZWorkflowEventType
 {
 	const TYPE_ID = 'nxcsocialnetworkspublish';
 
-	private static $classAttributes = array();
-	private static $handlerNames    = array();
+	private static $classAttributes     = array();
+	private static $handlerNames        = array();
+	private static $shortenHandlerNames = array();
 
 	public function __construct() {
 		$this->eZWorkflowEventType( self::TYPE_ID, 'Publish to Social Networks' );
@@ -81,6 +82,7 @@ class nxcSocialNetworksPublishType extends eZWorkflowEventType
 		return array(
 			'handlers',
 			'available_handler_names',
+			'available_shorten_handler_names',
 			'contentclass_attribute_list',
 			'affected_class_ids'
 		);
@@ -104,6 +106,20 @@ class nxcSocialNetworksPublishType extends eZWorkflowEventType
 				}
 
 				return self::$handlerNames;
+			}
+			case 'available_shorten_handler_names': {
+				if( count( self::$shortenHandlerNames ) === 0 ) {
+					$types = nxcSocialNetworksLinkShortenHandler::getHandlers();
+					foreach( $types as $type => $shortenHandlerClass ) {
+						try {
+							$shortenHandler = new $shortenHandlerClass( array() );
+							self::$shortenHandlerNames[ $type ] = $shortenHandler->name;
+							unset( $shortenHandler );
+						} catch( Exception $e ) {}
+					}
+				}
+
+				return self::$shortenHandlerNames;
 			}
 			case 'contentclass_attribute_list': {
 				if( count( self::$classAttributes ) === 0 ) {
@@ -230,7 +246,7 @@ class nxcSocialNetworksPublishType extends eZWorkflowEventType
 
 		$affectedClassIDs = array();
 
-		$optionNames = array( 'publish_only_on_create', 'include_url', 'shorten_url' );
+		$optionNames = array( 'publish_only_on_create', 'include_url', 'shorten_url', 'shorten_handler' );
 		$options     = array();
 		$var         = 'WorkflowEvent_event_nxcsocialnetworkspublish_handler_options';
 		if( $http->hasPostVariable( $var ) ) {


### PR DESCRIPTION
Implemented: Url link shorten handler workflow event option drop down menu

Hello NXC,

The system of url link shorten handlers was previously only configurable via ini settings which as we all know is not the most user friendly for website administrators or other end users.

Our pull request changes the configuration flexibility of the url link shorten handler system by allowing the link handler ('service') used to shorten urls to be chosen per social network via workflow event options in the admin.

The default link shortening service is still 'goo.gl'. We support this by default because it does not require an api key to use the service and is the most reliable/available.

The order of link shortening services / handlers displayed in the workflow event options dropdown is configurable via ini settings order, first listed, first displayed.

We think this improvement is worth of a pull request because it increases the flexibility from just one choice for link shortening service for all possible uses to a unique link shortening service choice for each workflow event social network.

Please let us know what you think!

Cheers,
Brookins Consulting
